### PR TITLE
Extract ValueType ser/deser and add addValueType() to builder

### DIFF
--- a/src/main/java/org/requirementsascode/moonwlker/MoonwlkerModule.java
+++ b/src/main/java/org/requirementsascode/moonwlker/MoonwlkerModule.java
@@ -5,11 +5,15 @@ import org.requirementsascode.moonwlker.paramnames.ParameterExtractor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.requirementsascode.moonwlker.values.ValueTypeDeserializer;
+import org.requirementsascode.moonwlker.values.ValueTypeSerializer;
+
+import java.util.function.Function;
 
 /**
  * Main entry point for the Moonwlker API. Register an instance of this class to configure
  * a Jackson's ObjectMapper instance.
- * 
+ *
  * @author b_muth
  *
  */
@@ -19,14 +23,14 @@ public class MoonwlkerModule extends SimpleModule {
    *  The object mapper configurer
    */
   private ObjectMapperConfigurer objectMapperConfigurer;
-  
+
   private MoonwlkerModule() {
     super("Moonwlker");
   }
 
   /**
    * Starts building a module for configuring Jackson's ObjectMapper instances.
-   * 
+   *
    * @return a builder.
    */
   public static MoonwlkerModuleBuilder builder() {
@@ -43,10 +47,10 @@ public class MoonwlkerModule extends SimpleModule {
     ObjectMapper objectMapper = context.getOwner();
     objectMapperConfigurer().configure(objectMapper);
   }
-  
+
   /**
    * Builder for a Moonwlker module.
-   * 
+   *
    * @author b_muth
    *
    */
@@ -55,10 +59,10 @@ public class MoonwlkerModule extends SimpleModule {
     private MoonwlkerModuleBuilder() {
       setObjectMapperConfigurer(new ObjectMapperConfigurer(this));
     }
-    
+
     /**
      * Starts building a module for configuring Jackson's ObjectMapper instances.
-     * 
+     *
      * @param typePropertyName the name of property in JSON that contains the target class name.
      * @return a builder.
      */
@@ -68,24 +72,33 @@ public class MoonwlkerModule extends SimpleModule {
       } else if(typePropertyName.length() == 0) {
         throw new IllegalArgumentException("typePropertyName must not be empty String!");
       }
-      
+
       PropertyMappingBuilder builder = new PropertyMappingBuilder(objectMapperConfigurer(), typePropertyName);
       return builder;
     }
-    
+
     /**
      * Creates a Moonwlker module based on the builder methods called so far.
-     * 
+     *
      * @return the module
      */
     public MoonwlkerModule build() {
       return MoonwlkerModule.this;
     }
+
+    public <T> MoonwlkerModuleBuilder addValueType(Class<T> valueType, Function<T, String> valueToString, Function<String, T> stringToValue) {
+      ValueTypeSerializer<T> serializer = new ValueTypeSerializer<>(valueType, valueToString);
+      ValueTypeDeserializer<T> deserializer = new ValueTypeDeserializer<>(valueType, stringToValue);
+
+      addSerializer(valueType, serializer);
+      addDeserializer(valueType, deserializer);
+      return this;
+    }
   }
-  
+
   /**
    * Returns the object mapper configurer for this module.
-   * 
+   *
    * @return the configurer
    */
   private ObjectMapperConfigurer objectMapperConfigurer() {
@@ -94,7 +107,7 @@ public class MoonwlkerModule extends SimpleModule {
 
   /**
    * Specifies the object mapper configurer for this module.
-   * 
+   *
    * @param objectMapperBuilder the builder
    */
   private void setObjectMapperConfigurer(ObjectMapperConfigurer objectMapperBuilder) {

--- a/src/main/java/org/requirementsascode/moonwlker/values/ValueTypeDeserializer.java
+++ b/src/main/java/org/requirementsascode/moonwlker/values/ValueTypeDeserializer.java
@@ -1,0 +1,26 @@
+package org.requirementsascode.moonwlker.values;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public class ValueTypeDeserializer<T> extends StdDeserializer<T> {
+    private final Function<String, T> stringToValue;
+
+    public ValueTypeDeserializer(Class<T> valueType, Function<String, T> stringToValue) {
+        super(valueType);
+        this.stringToValue = requireNonNull(stringToValue, "stringToValue must be non-null!");
+    }
+
+    @Override
+    public T deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        String stringValue = jp.getValueAsString();
+        T value = stringToValue.apply(stringValue);
+        return value;
+    }
+}

--- a/src/main/java/org/requirementsascode/moonwlker/values/ValueTypeSerializer.java
+++ b/src/main/java/org/requirementsascode/moonwlker/values/ValueTypeSerializer.java
@@ -1,0 +1,26 @@
+package org.requirementsascode.moonwlker.values;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public class ValueTypeSerializer<T> extends StdSerializer<T> {
+    private final Function<T, String> valueToString;
+
+    public ValueTypeSerializer(Class<T> t, Function<T, String> valueToString) {
+        super(t);
+        this.valueToString = requireNonNull(valueToString, "valueToString must be non-null!");
+    }
+
+    @Override
+    public void serialize(T value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException {
+        String valueAsString = valueToString.apply(value);
+        jgen.writeString(valueAsString);
+    }
+}

--- a/src/test/java/org/requirementsascode/moonwlker/ValueTest.java
+++ b/src/test/java/org/requirementsascode/moonwlker/ValueTest.java
@@ -1,24 +1,12 @@
 package org.requirementsascode.moonwlker;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
-import java.util.function.Function;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.requirementsascode.moonwlker.testobject.animal.ObjectWithJsonValue;
 import org.requirementsascode.moonwlker.testobject.animal.OrphanAnimal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 public class ValueTest extends MoonwlkerModuleTest {
 
@@ -57,55 +45,16 @@ public class ValueTest extends MoonwlkerModuleTest {
     var object = new ObjectWithJsonValue("blah", orphanAnimal);
     assertEquals("{\"someString\":\"blah\",\"orphanAnimal\":\"Boo\"}", writeToJson(objectMapper, object));
   }
-  
-  private ObjectMapper getObjectMapper() {
-    return getObjectMapper(OrphanAnimal.class, OrphanAnimal::getName, OrphanAnimal::new);
-  }
 
-  private <T> ObjectMapper getObjectMapper(Class<T> valueType, Function<T, String> valueToString, Function<String, T> stringToValue) {
-    ValueTypeSerializer<T> serializer = new ValueTypeSerializer<>(valueType, valueToString);
-    ValueTypeDeserializer<T> deserializer = new ValueTypeDeserializer<>(valueType, stringToValue);
-    
-    MoonwlkerModule module = MoonwlkerModule.builder().build();
-    module.addSerializer(valueType, serializer);
-    module.addDeserializer(valueType, deserializer);
+  private ObjectMapper getObjectMapper() {
+
+    MoonwlkerModule module = MoonwlkerModule.builder()
+            .addValueType(OrphanAnimal.class, OrphanAnimal::getName, OrphanAnimal::new)
+            .build();
 
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.registerModule(module);
     return objectMapper;
   }
 
-  @SuppressWarnings("serial")
-  class ValueTypeSerializer<T> extends StdSerializer<T> {
-    private final Function<T, String> valueToString;
-
-    public ValueTypeSerializer(Class<T> t, Function<T, String> valueToString) {
-      super(t);
-      this.valueToString = requireNonNull(valueToString, "valueToString must be non-null!");
-    }
-
-    @Override
-    public void serialize(T value, JsonGenerator jgen, SerializerProvider provider)
-        throws IOException, JsonProcessingException {
-      String valueAsString = valueToString.apply(value);
-      jgen.writeString(valueAsString);
-    }
-  }
-  
-  @SuppressWarnings("serial")
-  class ValueTypeDeserializer<T> extends StdDeserializer<T> {
-    private final Function<String, T> stringToValue;
-
-    public ValueTypeDeserializer(Class<?> valueType, Function<String, T> stringToValue) {
-      super(valueType);
-      this.stringToValue = requireNonNull(stringToValue, "stringToValue must be non-null!");
-    }
-
-    @Override
-    public T deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-      String stringValue = jp.getValueAsString();
-      T value = stringToValue.apply(stringValue);
-      return value;
-    }
-  }
 }


### PR DESCRIPTION
This should make it easy to configure now.

e.g.

``` java
ObjectMapper objectMapper = new ObjectMapper();

MoonwlkerModule module =
  MoonwlkerModule.builder()
    .addValueType(OrphanAnimal.class, OrphanAnimal::getName, OrphanAnimal::new)
    .fromProperty("type").toSubclassesOf(Person.class)
    .build();

objectMapper.registerModule(module);
```
